### PR TITLE
Allow roosay quote to be specified at the command line

### DIFF
--- a/src/quote.py
+++ b/src/quote.py
@@ -57,6 +57,8 @@ def print_usage():
     print("Usage:")
     print("\t-a quote \t: Adds a quote to the quotes list")
     print("\t-h \t\t: Prints usage message")
+    print("\t--<ASCII image to use> : name of a file (excluding extension) in "
+            "the \"asciiArt\" directory to use for the ASCII image")
 
 
 def add_quote():

--- a/src/quote.py
+++ b/src/quote.py
@@ -57,6 +57,7 @@ def print_usage():
     print("Usage:")
     print("\t-a quote \t: Adds a quote to the quotes list")
     print("\t-h \t\t: Prints usage message")
+    print("\t-q quote \t: Print this quote")
     print("\t--<ASCII image to use> : name of a file (excluding extension) in "
             "the \"asciiArt\" directory to use for the ASCII image")
 
@@ -91,6 +92,12 @@ def main():
                 add_quote()
             else:
                 print("You forgot to enter a quote.")
+        elif sys.argv[1].lower() == '-q':
+            if len(sys.argv) > 2:
+                quote = ' '.join(sys.argv[2:])
+                print_message(quote)
+            else:
+                print('You forgot to enter a quote.')
         elif sys.argv[1][:2] == "--":
             quotes = module.input_file(INPUT_FILE)
             print_message(quotes[random.randint(0,(len(quotes) -1))], ascii_file=sys.argv[1][2:]+'.txt')


### PR DESCRIPTION
I was going through my old Git repos and found that I had this patch that I never pushed anywhere, so I decided to push it to my fork and open a PR. This PR adds a `-q` command line flag to the src/quote.py script that allows you to specify a quote for roosay to say instead of picking a random one from a file, like so: `python3 src/quote.py -q Python is cool`. It just reads all command line arguments after the `-q` flag and uses them for the quote, so this must be the last flag supplied to the script.

This is somewhat unrelated but I also added a line to the usage message describing what seemed to be an undocumented command line flag where you could specify which ASCII art you wanted to use with double dashes: `python3 src/quote.py --bat`.